### PR TITLE
feat: add scroll behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ MultiAxisAutoScroll(
 
 _Notice again, that the vertical and horizontal controller should be the same as those attached to your scrollables._
 
+To add autoscroll to every scrollables, add the following line to MaterialApp:
+
+```dart
+MaterialApp(
+  scrollBehavior: MaterialAutoScrollBehavior(),
+  ...,
+)
+```
+
+There is also `CupertinoAutoScrollBehavior` for Cupertino widget set.
+
 ## Customization
 
 Both `AutoScroll` and `MultiAxisAutoScroll` support custom anchor and cursor widgets.

--- a/lib/auto_scrolling.dart
+++ b/lib/auto_scrolling.dart
@@ -7,4 +7,5 @@ library;
 export 'src/anchors/anchors.dart';
 export 'src/auto_scroll_widgets/auto_scroll_widgets.dart';
 export 'src/cursors/cursors.dart';
+export 'src/scroll_behavior/scroll_behavior.dart';
 export 'src/utils.dart';

--- a/lib/src/scroll_behavior/cupertino.dart
+++ b/lib/src/scroll_behavior/cupertino.dart
@@ -1,0 +1,54 @@
+import 'package:auto_scrolling/auto_scrolling.dart';
+import 'package:flutter/cupertino.dart';
+
+/// Describes how [Scrollable] widgets behave for [CupertinoApp]s.
+///
+/// This is an extension of the default [CupertinoScrollBehavior], providing
+/// [AutoScroll] for every [Scrollable] widget.
+///
+/// See also:
+///
+///  * [ScrollBehavior], the default scrolling behavior extended by this class.
+///  * [CupertinoAutoScrollBehavior], alternative for Material widget set.
+class CupertinoAutoScrollBehavior extends CupertinoScrollBehavior {
+  /// Creates a CupertinoScrollBehavior that adds [AutoScroll]s on desktop
+  /// platforms in addition to default CupertinoScrollBehavior.
+  const CupertinoAutoScrollBehavior();
+
+  @override
+  Widget buildScrollbar(
+      BuildContext context, Widget child, ScrollableDetails details) {
+    switch (getPlatform(context)) {
+      case TargetPlatform.linux:
+      case TargetPlatform.macOS:
+      case TargetPlatform.windows:
+        switch (axisDirectionToAxis(details.direction)) {
+          case Axis.horizontal:
+            return AutoScroll(
+              controller: details.controller,
+              scrollDirection: Axis.horizontal,
+              anchorBuilder: (_) => const SingleDirectionAnchor(
+                direction: Axis.horizontal,
+              ),
+              child: CupertinoScrollbar(
+                controller: details.controller,
+                child: child,
+              ),
+            );
+          case Axis.vertical:
+            return AutoScroll(
+              controller: details.controller,
+              anchorBuilder: (_) => const SingleDirectionAnchor(),
+              child: CupertinoScrollbar(
+                controller: details.controller,
+                child: child,
+              ),
+            );
+        }
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.iOS:
+        return child;
+    }
+  }
+}

--- a/lib/src/scroll_behavior/material.dart
+++ b/lib/src/scroll_behavior/material.dart
@@ -9,43 +9,63 @@ import 'package:flutter/material.dart';
 /// See also:
 ///
 ///  * [ScrollBehavior], the default scrolling behavior extended by this class.
-///  * [CupertinoAutoScrollBehavior], alternative for Cupertino widget set.
+///  * [CupertinoAutoScrollBehavior], alternative for the Cupertino widget set.
 class MaterialAutoScrollBehavior extends MaterialScrollBehavior {
   /// Creates a MaterialScrollBehavior that adds [AutoScroll]s on desktop
   /// platforms in addition to default MaterialScrollBehavior.
-  const MaterialAutoScrollBehavior();
+  const MaterialAutoScrollBehavior({this.autoScrollBuilder});
+
+  /// The [AutoScroll] builder that is called to build the [AutoScroll] wrapper
+  /// to wrap every scroll views with [AutoScroll].
+  ///
+  /// If not provided, a default [AutoScroll] with [SingleDirectionAnchor]
+  // widget will be used.
+  ///
+  final Widget Function(
+    Widget child,
+    Axis axis,
+    ScrollController? controller,
+  )? autoScrollBuilder;
+
+  Widget _defaultAutoScroll(
+    Widget child,
+    Axis axis,
+    ScrollController? controller,
+  ) =>
+      AutoScroll(
+        controller: controller,
+        scrollDirection: axis,
+        anchorBuilder: (_) => SingleDirectionAnchor(
+          direction: axis,
+        ),
+        child: child,
+      );
 
   @override
   Widget buildScrollbar(
-      BuildContext context, Widget child, ScrollableDetails details) {
+    BuildContext context,
+    Widget child,
+    ScrollableDetails details,
+  ) {
+    final axis = axisDirectionToAxis(details.direction);
+    final autoScrollWrapper = autoScrollBuilder ?? _defaultAutoScroll;
+
     switch (getPlatform(context)) {
       case TargetPlatform.linux:
       case TargetPlatform.macOS:
       case TargetPlatform.windows:
         assert(details.controller != null, 'Controller cannot be null.');
-        switch (axisDirectionToAxis(details.direction)) {
-          case Axis.horizontal:
-            return AutoScroll(
-              controller: details.controller,
-              scrollDirection: Axis.horizontal,
-              anchorBuilder: (_) => const SingleDirectionAnchor(
-                direction: Axis.horizontal,
-              ),
-              child: Scrollbar(
+        return autoScrollWrapper(
+          switch (axis) {
+            Axis.horizontal => child,
+            Axis.vertical => Scrollbar(
                 controller: details.controller,
                 child: child,
-              ),
-            );
-          case Axis.vertical:
-            return AutoScroll(
-              controller: details.controller,
-              anchorBuilder: (_) => const SingleDirectionAnchor(),
-              child: Scrollbar(
-                controller: details.controller,
-                child: child,
-              ),
-            );
-        }
+              )
+          },
+          axis,
+          details.controller,
+        );
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.iOS:

--- a/lib/src/scroll_behavior/material.dart
+++ b/lib/src/scroll_behavior/material.dart
@@ -1,0 +1,55 @@
+import 'package:auto_scrolling/auto_scrolling.dart';
+import 'package:flutter/material.dart';
+
+/// Describes how [Scrollable] widgets behave for [MaterialApp]s.
+///
+/// This is an extension of the default [MaterialScrollBehavior], providing
+/// [AutoScroll] for every [Scrollable] widget.
+///
+/// See also:
+///
+///  * [ScrollBehavior], the default scrolling behavior extended by this class.
+///  * [CupertinoAutoScrollBehavior], alternative for Cupertino widget set.
+class MaterialAutoScrollBehavior extends MaterialScrollBehavior {
+  /// Creates a MaterialScrollBehavior that adds [AutoScroll]s on desktop
+  /// platforms in addition to default MaterialScrollBehavior.
+  const MaterialAutoScrollBehavior();
+
+  @override
+  Widget buildScrollbar(
+      BuildContext context, Widget child, ScrollableDetails details) {
+    switch (getPlatform(context)) {
+      case TargetPlatform.linux:
+      case TargetPlatform.macOS:
+      case TargetPlatform.windows:
+        assert(details.controller != null, 'Controller cannot be null.');
+        switch (axisDirectionToAxis(details.direction)) {
+          case Axis.horizontal:
+            return AutoScroll(
+              controller: details.controller,
+              scrollDirection: Axis.horizontal,
+              anchorBuilder: (_) => const SingleDirectionAnchor(
+                direction: Axis.horizontal,
+              ),
+              child: Scrollbar(
+                controller: details.controller,
+                child: child,
+              ),
+            );
+          case Axis.vertical:
+            return AutoScroll(
+              controller: details.controller,
+              anchorBuilder: (_) => const SingleDirectionAnchor(),
+              child: Scrollbar(
+                controller: details.controller,
+                child: child,
+              ),
+            );
+        }
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.iOS:
+        return child;
+    }
+  }
+}

--- a/lib/src/scroll_behavior/material.dart
+++ b/lib/src/scroll_behavior/material.dart
@@ -10,9 +10,11 @@ import 'package:flutter/material.dart';
 ///
 ///  * [ScrollBehavior], the default scrolling behavior extended by this class.
 ///  * [CupertinoAutoScrollBehavior], alternative for the Cupertino widget set.
+///
 class MaterialAutoScrollBehavior extends MaterialScrollBehavior {
   /// Creates a MaterialScrollBehavior that adds [AutoScroll]s on desktop
   /// platforms in addition to default MaterialScrollBehavior.
+  ///
   const MaterialAutoScrollBehavior({this.autoScrollBuilder});
 
   /// The [AutoScroll] builder that is called to build the [AutoScroll] wrapper

--- a/lib/src/scroll_behavior/scroll_behavior.dart
+++ b/lib/src/scroll_behavior/scroll_behavior.dart
@@ -1,0 +1,2 @@
+export 'cupertino.dart';
+export 'material.dart';


### PR DESCRIPTION
ScrollBehavior allows the injection of `AutoScroll` widget into every scrollables.

It comes with the default anchor and no custom cursors. Which I would argue is a simpler and better default, similar to the default autoscroll found in Firefox. This can be further enhanced with the addition of `AutoScrollTheme` as discussed in #42, allowing user to give a theme globally that suits their design goal.

Test and example not included. I'm not sure what to test.