### PR TITLE
feat: add Fluent scroll behavior

### DIFF
--- a/lib/src/scroll_behavior/cupertino.dart
+++ b/lib/src/scroll_behavior/cupertino.dart
@@ -10,6 +10,7 @@ import 'package:flutter/cupertino.dart';
 ///
 ///  * [ScrollBehavior], the default scrolling behavior extended by this class.
 ///  * [MaterialAutoScrollBehavior], alternative for the Material widget set.
+///  * [FluentAutoScrollBehavior], alternative for the Fluent widget set.
 ///
 class CupertinoAutoScrollBehavior extends CupertinoScrollBehavior {
   /// Creates a CupertinoScrollBehavior that adds [AutoScroll]s on desktop

--- a/lib/src/scroll_behavior/fluent.dart
+++ b/lib/src/scroll_behavior/fluent.dart
@@ -1,22 +1,25 @@
 import 'package:auto_scrolling/auto_scrolling.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
-/// Describes how [Scrollable] widgets behave for [MaterialApp]s.
+/// Describes how [Scrollable] widgets behave for `FluentApp`s from `fluent_ui`
+/// package.
 ///
-/// This is an extension of the default [MaterialScrollBehavior], providing
-/// [AutoScroll] for every [Scrollable] widget.
+/// This is an extension of the default [ScrollBehavior] resembling
+/// `FluentScrollBehavior`, providing [AutoScroll] for every [Scrollable]
+/// widget.
 ///
 /// See also:
 ///
 ///  * [ScrollBehavior], the default scrolling behavior extended by this class.
+///  * [MaterialAutoScrollBehavior], alternative for the Material widget set.
 ///  * [CupertinoAutoScrollBehavior], alternative for the Cupertino widget set.
-///  * [FluentAutoScrollBehavior], alternative for the Fluent widget set.
 ///
-class MaterialAutoScrollBehavior extends MaterialScrollBehavior {
-  /// Creates a MaterialScrollBehavior that adds [AutoScroll]s on desktop
-  /// platforms in addition to default MaterialScrollBehavior.
+class FluentAutoScrollBehavior extends ScrollBehavior {
+  /// Creates a ScrollBehavior that adds [AutoScroll]s on desktop platforms
+  /// in addition to default ScrollBehavior.
   ///
-  const MaterialAutoScrollBehavior({this.autoScrollBuilder});
+  const FluentAutoScrollBehavior({this.autoScrollBuilder});
 
   /// The [AutoScroll] builder that is called to build the [AutoScroll] wrapper
   /// to wrap every scroll views with [AutoScroll].
@@ -54,8 +57,21 @@ class MaterialAutoScrollBehavior extends MaterialScrollBehavior {
     final autoScrollWrapper = autoScrollBuilder ?? _defaultAutoScroll;
 
     switch (getPlatform(context)) {
-      case TargetPlatform.linux:
       case TargetPlatform.macOS:
+      case TargetPlatform.iOS:
+        assert(details.controller != null, 'Controller cannot be null.');
+        return autoScrollWrapper(
+          switch (axis) {
+            Axis.horizontal => child,
+            Axis.vertical => CupertinoScrollbar(
+                controller: details.controller,
+                child: child,
+              ),
+          },
+          axis,
+          details.controller,
+        );
+      case TargetPlatform.linux:
       case TargetPlatform.windows:
         assert(details.controller != null, 'Controller cannot be null.');
         return autoScrollWrapper(
@@ -64,14 +80,13 @@ class MaterialAutoScrollBehavior extends MaterialScrollBehavior {
             Axis.vertical => Scrollbar(
                 controller: details.controller,
                 child: child,
-              )
+              ),
           },
           axis,
           details.controller,
         );
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
-      case TargetPlatform.iOS:
         return child;
     }
   }

--- a/lib/src/scroll_behavior/scroll_behavior.dart
+++ b/lib/src/scroll_behavior/scroll_behavior.dart
@@ -1,2 +1,3 @@
 export 'cupertino.dart';
+export 'fluent.dart';
 export 'material.dart';


### PR DESCRIPTION
This should resembles [`FluentScrollBehavior`](https://pub.dev/documentation/fluent_ui/latest/fluent_ui/FluentScrollBehavior-class.html) from `fluent_ui` package, as the current latest `4.11.2` version.

This doesn't require `fluent_ui` as dependency since `FluentScrollBehavior` only uses Material and Cupertino widgets.

This seems to also resembles the ScrollBehavior for `flutter-shadcn-ui`.